### PR TITLE
build: ensure that libjudger library is built as static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,14 @@ project(judger C)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/output)
 
-set(CMAKE_C_FLAGS "-g -Wall -Werror -O3 -std=c99 -pie -fPIC")
+set(CMAKE_C_FLAGS "-g -Wall -Werror -O3 -std=c99 -static -pie -fPIC")
 
 # make judger lib
 file(GLOB SOURCE "src/*.c" "src/rules/*.c")
-add_executable(libjudger.so ${SOURCE})
-target_link_libraries(libjudger.so pthread seccomp)
+add_executable(libjudger.a ${SOURCE})
+target_link_libraries(libjudger.a pthread seccomp)
 
 
-install(FILES output/libjudger.so
+install(FILES output/libjudger.a
     PERMISSIONS OWNER_EXECUTE OWNER_READ
     DESTINATION /usr/lib/judger)


### PR DESCRIPTION
`CMakeLists.txt`를 수정하여서, `libjudger.so` 대신 `libjudger.a`로 빌드가 될 수 있도록 합니다.