### PR TITLE
Revert "fix: modify general seccomp rule"

### DIFF
--- a/src/rules/general.c
+++ b/src/rules/general.c
@@ -11,12 +11,7 @@
 int general_seccomp_rules(struct config *_config) {
     int syscalls_blacklist[] = {SCMP_SYS(clone),
                                 SCMP_SYS(fork), SCMP_SYS(vfork),
-                                SCMP_SYS(kill), SCMP_SYS(getdents),
-                                SCMP_SYS(getdents64), SCMP_SYS(prctl),
-                                SCMP_SYS(mkdir), SCMP_SYS(rmdir),
-                                SCMP_SYS(chdir), SCMP_SYS(chmod),
-                                SCMP_SYS(chown), SCMP_SYS(syslog),
-                                SCMP_SYS(rename), SCMP_SYS(unlink),
+                                SCMP_SYS(kill), 
 #ifdef __NR_execveat
                                 SCMP_SYS(execveat)
 #endif


### PR DESCRIPTION
Python 부팅 시 getdents64 시스템 콜을 항상 불러오기 때문에 해당 콜을 막아버리면 정상적인 채점이 불가함
Judger의 seccomp는 원래대로 유지하고 백엔드 레벨에서 패턴 탐지를 통해 채점 서버의 디렉토리 접근을 차단하도록 구현